### PR TITLE
Fix ESPHome config for recent releases and formatting issues

### DIFF
--- a/firmware/esphome/esp32-duo-media-player.yaml
+++ b/firmware/esphome/esp32-duo-media-player.yaml
@@ -6,15 +6,12 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: false
-  project:
-    name: esphome.web
-    version: '1.0'
-    on_boot:
-      priority: 800
-      then:
-      - media_player.volume_set:
-          id: esp32duo
-          volume: 50%
+  on_boot:
+    priority: 800
+    then:
+    - media_player.volume_set:
+        id: esp32duo
+        volume: 50%
 
 esp32:
   board: esp32dev
@@ -23,13 +20,14 @@ esp32:
 
 # Enable logging
 logger:
-  level: DEBUG
+#  level: DEBUG
   
 # Enable Home Assistant API
 api:
 
 # Allow Over-The-Air updates
 ota:
+  platform: esphome
   password: !secret esphome_ota_password
 
 wifi:

--- a/firmware/esphome/esp32-s2-solo-media-player.yaml
+++ b/firmware/esphome/esp32-s2-solo-media-player.yaml
@@ -6,15 +6,12 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: false
-  project:
-    name: esphome.web
-    version: '1.0'
-    on_boot:
-      priority: 800
-      then:
-      - media_player.volume_set:
-          id: esp32s2solo
-          volume: 50%
+  on_boot:
+    priority: 800
+    then:
+    - media_player.volume_set:
+        id: esp32s2solo
+        volume: 50%
 
 esp32:
   board: esp32-s2-saola-1
@@ -31,6 +28,7 @@ api:
 
 # Allow Over-The-Air updates
 ota:
+  platform: esphome
   password: !secret esphome_ota_password
 
 wifi:

--- a/firmware/esphome/esp32-s3-solo-media-player.yaml
+++ b/firmware/esphome/esp32-s3-solo-media-player.yaml
@@ -6,15 +6,12 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: false
-  project:
-    name: esphome.web
-    version: '1.0'
-    on_boot:
-      priority: 800
-      then:
-      - media_player.volume_set:
-          id: esp32s3solo
-          volume: 50%
+  on_boot:
+    priority: 800
+    then:
+    - media_player.volume_set:
+        id: esp32s3solo
+        volume: 50%
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -31,6 +28,7 @@ api:
 
 # Allow Over-The-Air updates
 ota:
+  platform: esphome
   password: !secret esphome_ota_password
 
 wifi:

--- a/firmware/esphome/louder-esp32-media-player.yaml
+++ b/firmware/esphome/louder-esp32-media-player.yaml
@@ -40,6 +40,7 @@ api:
 
 # Allow Over-The-Air updates
 ota:
+  platform: esphome
   password: !secret esphome_ota_password
 
 wifi:


### PR DESCRIPTION
* Removes Project (not needed, but could be used for this project - I didn't bother looking up best practices, sorry).
* Fixes indentation on on_boot
* Fixes ota to specify platform (required since ESPHome 2024.05 or 2024.06 I believe