### PR TITLE
feat(esphome): turn on/off Amp on media_player usage, add manufacturer info

### DIFF
--- a/firmware/esphome/esp32-duo-media-player.yaml
+++ b/firmware/esphome/esp32-duo-media-player.yaml
@@ -5,6 +5,9 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
+  project:
+    name: Sonocotta.ESP32-Duo
+    version: '1.0'
   name_add_mac_suffix: false
   on_boot:
     priority: 800

--- a/firmware/esphome/esp32-s2-solo-media-player.yaml
+++ b/firmware/esphome/esp32-s2-solo-media-player.yaml
@@ -5,6 +5,9 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
+  project:
+    name: Sonocotta.ESP32-S2-Solo
+    version: '1.0'
   name_add_mac_suffix: false
   on_boot:
     priority: 800

--- a/firmware/esphome/esp32-s3-solo-media-player.yaml
+++ b/firmware/esphome/esp32-s3-solo-media-player.yaml
@@ -5,6 +5,9 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
+  project:
+    name: Sonocotta.ESP32-S3-Solo
+    version: '1.0'
   name_add_mac_suffix: false
   on_boot:
     priority: 800

--- a/firmware/esphome/louder-esp32-media-player.yaml
+++ b/firmware/esphome/louder-esp32-media-player.yaml
@@ -76,6 +76,21 @@ i2s_audio:
   i2s_lrclk_pin: GPIO25
   i2s_bclk_pin: GPIO26
 
+interval:
+  - interval: 1min
+    then:
+      - if:
+          condition:
+            - switch.is_on: amp
+            - for:
+                time: 30s
+                condition:
+                  or:
+                    - media_player.is_idle: louderesp32
+                    - media_player.is_paused: louderesp32
+          then:
+            - switch.turn_off: amp
+
 media_player:
   - platform: i2s_audio
     name: $friendly_name

--- a/firmware/esphome/louder-esp32-media-player.yaml
+++ b/firmware/esphome/louder-esp32-media-player.yaml
@@ -5,6 +5,9 @@ substitutions:
 esphome:
   name: "${name}"
   name_add_mac_suffix: false
+  project:
+    name: Sonocotta.Louder ESP32
+    version: '1.0'
   comment: "${friendly_name} Louder ESP32 ${pcb_version}"
   includes:
     - louderesp32.h

--- a/firmware/esphome/louder-esp32-media-player.yaml
+++ b/firmware/esphome/louder-esp32-media-player.yaml
@@ -64,6 +64,7 @@ switch:
       return {tas5805};
     switches:
       name: "Enable Amp"
+      id: amp
 
 i2c:
   sda: GPIO21
@@ -82,3 +83,5 @@ media_player:
     dac_type: external
     i2s_dout_pin: GPIO22
     mode: stereo
+    on_play:
+      - switch.turn_on: amp

--- a/firmware/esphome/louder-esp32s3-media-player.yaml
+++ b/firmware/esphome/louder-esp32s3-media-player.yaml
@@ -72,6 +72,7 @@ switch:
       return {tas5805};
     switches:
       name: "Enable Amp"
+      id: amp
 
 i2c:
   sda: GPIO8
@@ -90,3 +91,5 @@ media_player:
     dac_type: external
     i2s_dout_pin: GPIO16
     mode: stereo
+    on_play:
+      - switch.turn_on: amp

--- a/firmware/esphome/louder-esp32s3-media-player.yaml
+++ b/firmware/esphome/louder-esp32s3-media-player.yaml
@@ -6,6 +6,10 @@ substitutions:
 esphome:
   name: "${name}"
   name_add_mac_suffix: false
+  project:
+    name: Sonocotta.Louder ESP32-S3
+    version: '1.0'
+  comment: "${friendly_name} Louder ESP32-S3 ${pcb_version}"
   includes:
     - include/louderesp32-s3.h
   platformio_options:
@@ -43,8 +47,8 @@ logger:
   
 # Enable Home Assistant API
 api:
-    encryption: 
-      key: !secret esphome_api_key
+  encryption:
+    key: !secret esphome_api_key
 
 # Allow Over-The-Air updates
 ota:

--- a/firmware/esphome/louder-esp32s3-media-player.yaml
+++ b/firmware/esphome/louder-esp32s3-media-player.yaml
@@ -84,6 +84,21 @@ i2s_audio:
   i2s_lrclk_pin: GPIO15
   i2s_bclk_pin: GPIO14
 
+interval:
+  - interval: 1min
+    then:
+      - if:
+          condition:
+            - switch.is_on: amp
+            - for:
+                time: 30s
+                condition:
+                  or:
+                    - media_player.is_idle: louderesp32
+                    - media_player.is_paused: louderesp32
+          then:
+            - switch.turn_off: amp
+
 media_player:
   - platform: i2s_audio
     name: $friendly_name


### PR DESCRIPTION
* This simulates the same behaviour as in Squeezelite, when music plays, the Amp will turn on. If no music playing for some time, the amp will auto turn off.
* Additionally, adding back the section `project`, as this will show **Manufacturer** and **Device name** in Home Assistant.