### PR TITLE
ESPHome - Add maximum volume feature to louder ESP

### DIFF
--- a/firmware/esphome/louder-esp32-media-player.yaml
+++ b/firmware/esphome/louder-esp32-media-player.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: "louder-esp32"
   friendly_name: Louder-ESP32 Media Player
-  max_volume: "0.9"  # If volume exceeds this we reset it to this.
+#  max_volume: "0.9"  # If volume exceeds this we reset it to this. Be sure to uncomment the code below "max_volume feature".
 
 esphome:
   name: "${name}"
@@ -104,17 +104,18 @@ media_player:
     mode: stereo
     on_play:
       - switch.turn_on: amp
-    on_state:
-      then:
-        - if:
-            condition:
-              lambda: |-
-                float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
-                float max_vol = roundf(${max_volume} * 100) / 100.0;
-                return current_volume > max_vol;
-            then:
-              - logger.log: "Volume exceeds max volume, resetting to max volume"
-              - media_player.volume_set:
-                  id: louderesp32
-                  volume: ${max_volume}
-              - logger.log: "Volume set to max volume"
+### max_volume feature - uncomment below to enable
+#     on_state:
+#       then:
+#         - if:
+#             condition:
+#               lambda: |-
+#                 float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
+#                 float max_vol = roundf(${max_volume} * 100) / 100.0;
+#                 return current_volume > max_vol;
+#             then:
+#               - logger.log: "Volume exceeds max volume, resetting to max volume"
+#               - media_player.volume_set:
+#                   id: louderesp32
+#                   volume: ${max_volume}
+#               - logger.log: "Volume set to max volume"

--- a/firmware/esphome/louder-esp32-media-player.yaml
+++ b/firmware/esphome/louder-esp32-media-player.yaml
@@ -1,6 +1,7 @@
 substitutions:
   name: "louder-esp32"
   friendly_name: Louder-ESP32 Media Player
+  max_volume: "0.9"  # If volume exceeds this we reset it to this.
 
 esphome:
   name: "${name}"
@@ -103,3 +104,17 @@ media_player:
     mode: stereo
     on_play:
       - switch.turn_on: amp
+    on_state:
+      then:
+        - if:
+            condition:
+              lambda: |-
+                float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
+                float max_vol = roundf(${max_volume} * 100) / 100.0;
+                return current_volume > max_vol;
+            then:
+              - logger.log: "Volume exceeds max volume, resetting to max volume"
+              - media_player.volume_set:
+                  id: louderesp32
+                  volume: ${max_volume}
+              - logger.log: "Volume set to max volume"

--- a/firmware/esphome/louder-esp32s3-media-player.yaml
+++ b/firmware/esphome/louder-esp32s3-media-player.yaml
@@ -2,6 +2,7 @@ substitutions:
   name: "louder-esp32"
   friendly_name: Louder-ESP32 Media Player
   pcb_version: "J"
+  max_volume: "0.9"  # If volume exceeds this we reset it to this.
 
 esphome:
   name: "${name}"
@@ -112,3 +113,17 @@ media_player:
     mode: stereo
     on_play:
       - switch.turn_on: amp
+    on_state:
+      then:
+        - if:
+            condition:
+              lambda: |-
+                float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
+                float max_vol = roundf(${max_volume} * 100) / 100.0;
+                return current_volume > max_vol;
+            then:
+              - logger.log: "Volume exceeds max volume, resetting to max volume"
+              - media_player.volume_set:
+                  id: louderesp32
+                  volume: ${max_volume}
+              - logger.log: "Volume set to max volume"

--- a/firmware/esphome/louder-esp32s3-media-player.yaml
+++ b/firmware/esphome/louder-esp32s3-media-player.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "louder-esp32"
   friendly_name: Louder-ESP32 Media Player
   pcb_version: "J"
-  max_volume: "0.9"  # If volume exceeds this we reset it to this.
+#  max_volume: "0.9"  # If volume exceeds this we reset it to this. Be sure to uncomment the code below "max_volume feature".
 
 esphome:
   name: "${name}"
@@ -113,17 +113,18 @@ media_player:
     mode: stereo
     on_play:
       - switch.turn_on: amp
-    on_state:
-      then:
-        - if:
-            condition:
-              lambda: |-
-                float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
-                float max_vol = roundf(${max_volume} * 100) / 100.0;
-                return current_volume > max_vol;
-            then:
-              - logger.log: "Volume exceeds max volume, resetting to max volume"
-              - media_player.volume_set:
-                  id: louderesp32
-                  volume: ${max_volume}
-              - logger.log: "Volume set to max volume"
+### max_volume feature - uncomment below to enable
+#     on_state:
+#       then:
+#         - if:
+#             condition:
+#               lambda: |-
+#                 float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
+#                 float max_vol = roundf(${max_volume} * 100) / 100.0;
+#                 return current_volume > max_vol;
+#             then:
+#               - logger.log: "Volume exceeds max volume, resetting to max volume"
+#               - media_player.volume_set:
+#                   id: louderesp32
+#                   volume: ${max_volume}
+#               - logger.log: "Volume set to max volume"


### PR DESCRIPTION
I'm not sure if this is something others would find useful. I am using a speaker that technically has a 20W max, so I'm limiting max volume to make sure I don't exceed it. It would probably be fine without this, but just being careful.

I ran into some floating point comparison issues originally where for example I was seeing:

> [11:07:37][D][media_player:065]: 'ESP Louder 1' - Setting
[11:07:37][D][media_player:075]:   Volume: 0.89
[11:07:37][D][main:159]: Current Volume: 0.890000, Target Max Volume: 0.800000
[11:07:38][D][main:100]: Volume exceeds max volume, resetting to max volume
[11:07:38][D][media_player:065]: 'ESP Louder 1' - Setting
[11:07:38][D][media_player:075]:   Volume: 0.80
[11:07:38][D][main:159]: Current Volume: 0.800000, Target Max Volume: 0.800000
[11:07:38][D][main:100]: Volume exceeds max volume, resetting to max volume
[11:07:38][D][media_player:065]: 'ESP Louder 1' - Setting
[11:07:38][D][media_player:075]:   Volume: 0.80
[11:07:38][D][main:159]: Current Volume: 0.800000, Target Max Volume: 0.800000
[11:07:38][D][main:100]: Volume exceeds max volume, resetting to max volume
[11:07:38][D][media_player:065]: 'ESP Louder 1' - Setting
[11:07:38][D][media_player:075]:   Volume: 0.80
[11:07:38][D][main:159]: Current Volume: 0.800000, Target Max Volume: 0.800000
[11:07:38][D][main:100]: Volume exceeds max volume, resetting to max volume
[11:07:38][D][media_player:065]: 'ESP Louder 1' - Setting
[11:07:38][D][media_player:075]:   Volume: 0.80
[11:07:38][D][main:159]: Current Volume: 0.800000, Target Max Volume: 0.800000
[11:07:38][D][main:100]: Volume exceeds max volume, resetting to max volume
...

Then eventually the board would reset.

This is why I did the compare like this instead:
```
float current_volume = roundf(id(louderesp32).volume * 100) / 100.0;
float max_vol = roundf(${max_volume} * 100) / 100.0;
return current_volume > max_vol;
```

There may be a better way to implement this, I'm not sure.