### PR TITLE
Change gpio4 to 17 in esp32-s3-idf sendspin variant

### DIFF
--- a/firmware/esphome/amped-esp32-s3-idf-sendspin.yaml
+++ b/firmware/esphome/amped-esp32-s3-idf-sendspin.yaml
@@ -116,7 +116,7 @@ switch:
     icon: "mdi:speaker"
     name: Enable DAC
     id: enable_dac
-    pin: GPIO4
+    pin: GPIO17
     restore_mode: ALWAYS_OFF
 
 speaker:


### PR DESCRIPTION
I noticed in the sendspin config that the wrong gpio was used, so I couldn't get any sound from the speaker (jack was working fine).
Smal change, huge effect :-)