### PR TITLE
Add tas58xx dac config refresh_eq override for snapclient

### DIFF
--- a/.github/workflows/build-esphome-configs.yml
+++ b/.github/workflows/build-esphome-configs.yml
@@ -28,6 +28,7 @@ jobs:
           configs=$(find firmware/esphome -maxdepth 2 -name "*.yaml" -type f \
             | grep -v "/packages/" \
             | grep -v "/packages-archive/" \
+            | grep -v "/0-legacy-boards/" \
             | grep -v "/secrets/" \
             | grep -v "secrets.yaml" \
             | jq -R -s -c 'split("\n")[:-1]')

--- a/firmware/esphome/1-hifi-esp32/hifi-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/1-hifi-esp32/hifi-esp32-idf-snapclient.yaml
@@ -108,10 +108,10 @@ packages:
       - firmware/esphome/packages/oled.yaml
       # Option A: @c-MM original port of esp32-snapclient client
       # Basic implementation without DSP controls
-      # - firmware/esphome/packages/snapclient.yaml
+      # - firmware/esphome/packages/snapclient-new.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters for basic DACs and controls hardware DSP for DSP-enabled DACs like TAS5805M
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
@@ -120,7 +120,7 @@ packages:
   # ir_receiver: !include packages/ir-receiver.yaml
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   
   # oled: !include packages/oled.yaml

--- a/firmware/esphome/1-hifi-esp32/hifi-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/1-hifi-esp32/hifi-esp32-s3-idf-snapclient.yaml
@@ -115,7 +115,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters for basic DACs and controls hardware DSP for DSP-enabled DACs like TAS5805M
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
@@ -124,7 +124,7 @@ packages:
   # ir_receiver: !include packages/ir-receiver.yaml
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   
   # oled: !include packages/oled.yaml

--- a/firmware/esphome/2-loud-esp32/loud-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/2-loud-esp32/loud-esp32-idf-snapclient.yaml
@@ -116,7 +116,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters for basic DACs and controls hardware DSP for DSP-enabled DACs like TAS5805M
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
@@ -126,7 +126,8 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # dac-switch: !include packages/dac-switch.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   
   # oled: !include packages/oled.yaml

--- a/firmware/esphome/2-loud-esp32/loud-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/2-loud-esp32/loud-esp32-idf-snapclient.yaml
@@ -26,7 +26,7 @@ substitutions:
 
   # DAC enable pin (actually amp UNMUTE)
   dac_enable_pin: GPIO13
-  dac_enable_restore_mode: ALWAYS_ON
+  dac_enable_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/2-loud-esp32/loud-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/2-loud-esp32/loud-esp32-s3-idf-snapclient.yaml
@@ -26,7 +26,7 @@ substitutions:
 
   # DAC enable pin (actually amp UNMUTE)
   dac_enable_pin: GPIO17              # It is 17 on rev G an later. rev F uses GPIO08
-  dac_enable_restore_mode: ALWAYS_ON
+  dac_enable_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO09
@@ -120,7 +120,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters for basic DACs and controls hardware DSP for DSP-enabled DACs like TAS5805M
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
@@ -130,7 +130,8 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # dac-switch: !include packages/dac-switch.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   
   # oled: !include packages/oled.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-sendspin.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-sendspin.yaml
@@ -31,6 +31,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
@@ -130,7 +130,7 @@ packages:
       - firmware/esphome/packages/oled.yaml
       # Option A: @c-MM original port of esp32-snapclient client
       # Basic implementation without DSP controls
-      - firmware/esphome/packages/snapclient.yaml
+      # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs like TAS58XX
       # - firmware/esphome/packages/snapclient-with-dsp.yaml
@@ -149,3 +149,4 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
+  snapclient: !include packages/snapclient-new.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
@@ -151,5 +151,6 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
+  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
@@ -151,6 +151,6 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
-  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
@@ -38,7 +38,7 @@ substitutions:
   # tas58xx_volume_min: -60dB
   tas58xx_refresh_eq: MANUAL
   tas58xx_dac_restore_mode: ALWAYS_OFF
-  
+
   # RGB LED
   rgb_led_pin: GPIO12
   
@@ -152,3 +152,4 @@ packages:
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
+  eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
@@ -37,6 +37,7 @@ substitutions:
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
   tas58xx_refresh_eq: MANUAL
+  tas58xx_dac_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO12
@@ -117,7 +118,7 @@ packages:
     ref: main
     files:
       # Option A: TAS58xx configured with ganged 15-band EQ
-      - firmware/esphome/packages/dac-tas58xx.yaml
+      # - firmware/esphome/packages/dac-tas58xx.yaml
       # Option B: TAS58xx configured with individual 15-band EQ per channel
       # - firmware/esphome/packages/dac-tas58xx-biamp.yaml
       # Option C: TAS58xx configured with bi-amp mode, with filters applied to both channels (HF or LF)
@@ -139,7 +140,7 @@ packages:
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
   # # Debug/local development fallback:
-  # external_dac: !include packages/dac-tas58xx.yaml
+  external_dac: !include packages/dac-tas58xx.yaml
   # external_dac: !include packages/dac-tas58xx-biamp.yaml
   # external_dac: !include packages/dac-tas58xx-presets.yaml  # snapclient: !include packages/snapclient.yaml
   # # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
@@ -150,3 +151,4 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf-snapclient.yaml
@@ -36,6 +36,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  tas58xx_refresh_eq: MANUAL
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/3-louder-esp32/louder-esp32-idf.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-idf.yaml
@@ -32,6 +32,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-sendspin.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-sendspin.yaml
@@ -30,6 +30,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO21

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
@@ -155,6 +155,6 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
-  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
@@ -156,3 +156,4 @@ packages:
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
+  eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
@@ -14,7 +14,7 @@
 # ============================================================
 
 substitutions:
-  name: esphome-web-896908
+  name: esphome-web-f63c10
   friendly_name: Louder-ESP32-S3
   task_stack_in_psram: "true" 
 
@@ -37,6 +37,7 @@ substitutions:
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
   tas58xx_refresh_eq: MANUAL  
+  tas58xx_dac_restore_mode: ALWAYS_OFF
 
   # RGB LED
   rgb_led_pin: GPIO21
@@ -120,7 +121,7 @@ packages:
     ref: main
     files:
       # Option A: TAS58xx configured with ganged 15-band EQ
-      - firmware/esphome/packages/dac-tas58xx.yaml
+      # - firmware/esphome/packages/dac-tas58xx.yaml
       # Option B: TAS58xx configured with individual 15-band EQ per channel
       # - firmware/esphome/packages/dac-tas58xx-biamp.yaml
       # Option C: TAS58xx configured with bi-amp mode, with filters applied to both channels (HF or LF)
@@ -133,7 +134,7 @@ packages:
       - firmware/esphome/packages/oled.yaml
       # Option A: @c-MM original port of esp32-snapclient client
       # Basic implementation without DSP controls
-      - firmware/esphome/packages/snapclient.yaml
+      # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs like TAS58XX
       # - firmware/esphome/packages/snapclient-with-dsp.yaml
@@ -142,7 +143,7 @@ packages:
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
   # # Debug/local development fallback:
-  # external_dac: !include packages/dac-tas58xx.yaml
+  external_dac: !include packages/dac-tas58xx.yaml
   # external_dac: !include packages/dac-tas58xx-biamp.yaml
   # external_dac: !include packages/dac-tas58xx-presets.yaml  
   # snapclient: !include packages/snapclient.yaml
@@ -153,3 +154,5 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
@@ -36,7 +36,8 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
-  
+  tas58xx_refresh_eq: MANUAL  
+
   # RGB LED
   rgb_led_pin: GPIO21
 

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf-snapclient.yaml
@@ -155,5 +155,6 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
+  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf.yaml
+++ b/firmware/esphome/3-louder-esp32/louder-esp32-s3-idf.yaml
@@ -31,6 +31,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO21

--- a/firmware/esphome/4-amped-esp32/amped-esp32-idf-snapclient.yaml
+++ b/firmware/esphome/4-amped-esp32/amped-esp32-idf-snapclient.yaml
@@ -26,7 +26,7 @@ substitutions:
 
   # Amp UNMUTE pin
   amp_enable_pin: GPIO13
-  amp_enable_restore_mode: ALWAYS_ON
+  amp_enable_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO12
@@ -116,7 +116,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters for basic DACs and controls hardware DSP for DSP-enabled DACs like TAS5805M
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
@@ -126,7 +126,8 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # amp_unmute: !include packages/amp-unmute.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  amp_enable: !include packages/snapclient-addon-amp-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   
   # oled: !include packages/oled.yaml

--- a/firmware/esphome/4-amped-esp32/amped-esp32-s3-idf-snapclient.yaml
+++ b/firmware/esphome/4-amped-esp32/amped-esp32-s3-idf-snapclient.yaml
@@ -26,7 +26,7 @@ substitutions:
 
   # Amp UNMUTE pin
   amp_enable_pin: GPIO17
-  amp_enable_restore_mode: ALWAYS_ON
+  amp_enable_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO09
@@ -120,7 +120,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters for basic DACs and controls hardware DSP for DSP-enabled DACs like TAS5805M
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
@@ -130,7 +130,8 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # amp_unmute: !include packages/amp-unmute.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  amp_enable: !include packages/snapclient-addon-amp-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   
   # oled: !include packages/oled.yaml

--- a/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-plus-idf-snapclient.yaml
@@ -131,7 +131,7 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # oled: !include packages/oled.yaml
   snapclient: !include packages/snapclient-new.yaml
-  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml

--- a/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-plus-idf-snapclient.yaml
@@ -118,7 +118,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
@@ -130,6 +130,8 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # oled: !include packages/oled.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml

--- a/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-s3-plus-idf-snapclient.yaml
@@ -122,7 +122,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
       
       # Optional ethernet (replace wifi config if you use this, you need to exclude OLED package if you do this to free up SPI bus)
       # - firmware/esphome/packages/ethernet-w5500.yaml
@@ -134,6 +134,8 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # oled: !include packages/oled.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml

--- a/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/5-hifi-esp32-plus/hifi-esp32-s3-plus-idf-snapclient.yaml
@@ -135,7 +135,7 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # oled: !include packages/oled.yaml
   snapclient: !include packages/snapclient-new.yaml
-  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-sendspin.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-sendspin.yaml
@@ -31,6 +31,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
@@ -38,6 +38,7 @@ substitutions:
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
   tas58xx_refresh_eq: MANUAL
+  tas58xx_dac_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO12
@@ -132,7 +133,7 @@ packages:
       
       # Option A: @c-MM original port of esp32-snapclient client
       # Basic implementation without DSP controls
-      - firmware/esphome/packages/snapclient.yaml
+      # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs like TAS58XX
       # - firmware/esphome/packages/snapclient-with-dsp.yaml
@@ -141,7 +142,7 @@ packages:
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
   # # Debug/local development fallback:
-  # external_dac: !include packages/dac-tas58xx.yaml
+  external_dac: !include packages/dac-tas58xx.yaml
   # # external_dac: !include packages/dac-tas58xx-biamp.yaml
   # # external_dac: !include packages/dac-tas58xx-presets.yaml  
   # snapclient: !include packages/snapclient.yaml
@@ -153,3 +154,7 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  external_dac: !include packages/snapclient-addon-external-dac.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
+  eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
@@ -155,6 +155,6 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
-  external_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
@@ -37,6 +37,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  tas58xx_refresh_eq: MANUAL
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf-snapclient.yaml
@@ -119,7 +119,7 @@ packages:
     ref: main
     files:
       # Option A: TAS58xx configured with ganged 15-band EQ
-      - firmware/esphome/packages/dac-tas58xx.yaml
+      # - firmware/esphome/packages/dac-tas58xx.yaml
       # Option B: TAS58xx configured with individual 15-band EQ per channel
       # - firmware/esphome/packages/dac-tas58xx-biamp.yaml
       # Option C: TAS58xx configured with bi-amp mode, with filters applied to both channels (HF or LF)

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-plus-idf.yaml
@@ -32,6 +32,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO12

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-sendspin.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-sendspin.yaml
@@ -31,6 +31,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
 
   # RGB LED
   rgb_led_pin: GPIO21

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-snapclient.yaml
@@ -31,6 +31,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  tas58xx_refresh_eq: MANUAL
   
   # RGB LED
   rgb_led_pin: GPIO21

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-snapclient.yaml
@@ -157,6 +157,6 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
   snapclient: !include packages/snapclient-new.yaml
-  external_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-snapclient.yaml
@@ -32,6 +32,7 @@ substitutions:
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
   tas58xx_refresh_eq: MANUAL
+  tas58xx_dac_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO21
@@ -119,7 +120,7 @@ packages:
     ref: main
     files:
       # Option A: TAS58xx configured with ganged 15-band EQ
-      - firmware/esphome/packages/dac-tas58xx.yaml
+      # - firmware/esphome/packages/dac-tas58xx.yaml
       # Option B: TAS58xx configured with individual 15-band EQ per channel
       # - firmware/esphome/packages/dac-tas58xx-biamp.yaml
       # Option C: TAS58xx configured with bi-amp mode, with filters applied to both channels (HF or LF)
@@ -133,7 +134,7 @@ packages:
 
       # Option A: @c-MM original port of esp32-snapclient client
       # Basic implementation without DSP controls
-      - firmware/esphome/packages/snapclient.yaml
+      # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs like TAS58XX
       # - firmware/esphome/packages/snapclient-with-dsp.yaml
@@ -142,7 +143,7 @@ packages:
       # - firmware/esphome/packages/ethernet-w5500.yaml
 
   # # Debug/local development fallback:
-  # external_dac: !include packages/dac-tas58xx.yaml
+  external_dac: !include packages/dac-tas58xx.yaml
   # # external_dac: !include packages/dac-tas58xx-biamp.yaml
   # # external_dac: !include packages/dac-tas58xx-presets.yaml  
 
@@ -155,3 +156,7 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  external_dac: !include packages/snapclient-addon-external-dac.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
+  eq_enable: !include packages/snapclient-addon-tas58xx.yaml

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-voice-assist.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf-voice-assist.yaml
@@ -46,6 +46,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
 
   # RGB LED
   rgb_led_pin: GPIO21

--- a/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf.yaml
+++ b/firmware/esphome/7-louder-esp32-plus/louder-esp32-s3-plus-idf.yaml
@@ -31,6 +31,7 @@ substitutions:
   # tas58xx_analog_gain: 0db
   # tas58xx_volume_max: 0dB
   # tas58xx_volume_min: -60dB
+  # tas58xx_refresh_eq: AUTO
   
   # RGB LED
   rgb_led_pin: GPIO21

--- a/firmware/esphome/8-amped-esp32-plus/amped-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/8-amped-esp32-plus/amped-esp32-plus-idf-snapclient.yaml
@@ -32,7 +32,7 @@ substitutions:
   
   # Amp UNMUTE pin
   amp_enable_pin: GPIO13
-  amp_enable_restore_mode: ALWAYS_ON
+  amp_enable_restore_mode: ALWAYS_OFF
 
   # RGB LED
   rgb_led_pin: GPIO12
@@ -117,7 +117,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
 
       - firmware/esphome/packages/amp-unmute.yaml
       - firmware/esphome/packages/light.yaml
@@ -136,6 +136,9 @@ packages:
   # monitoring: !include packages/monitoring.yaml
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # oled: !include packages/oled.yaml
-  # # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
+  amp_enable: !include packages/snapclient-addon-amp-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
   # # ethernet: !include packages/ethernet-w5500.yaml

--- a/firmware/esphome/8-amped-esp32-plus/amped-esp32-plus-idf-snapclient.yaml
+++ b/firmware/esphome/8-amped-esp32-plus/amped-esp32-plus-idf-snapclient.yaml
@@ -137,7 +137,7 @@ packages:
   # monitoring_wifi: !include packages/monitoring-wifi.yaml
   # oled: !include packages/oled.yaml
   snapclient: !include packages/snapclient-new.yaml
-  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   amp_enable: !include packages/snapclient-addon-amp-enable.yaml
   # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml

--- a/firmware/esphome/8-amped-esp32-plus/amped-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/8-amped-esp32-plus/amped-esp32-s3-plus-idf-snapclient.yaml
@@ -32,7 +32,7 @@ substitutions:
   
   # Amp UNMUTE pin
   amp_enable_pin: GPIO17
-  amp_enable_restore_mode: ALWAYS_ON
+  amp_enable_restore_mode: ALWAYS_OFF
   
   # RGB LED
   rgb_led_pin: GPIO21
@@ -122,7 +122,7 @@ packages:
       # - firmware/esphome/packages/snapclient.yaml
       # Option B: @farmed-switch fork of the c-MM snapclient with added DSP controls
       # Implements software BQ-filters, but makes less sense for DSP-enabled DACs
-      - firmware/esphome/packages/snapclient-with-dsp.yaml
+      # - firmware/esphome/packages/snapclient-with-dsp.yaml
 
       - firmware/esphome/packages/amp-unmute.yaml
       - firmware/esphome/packages/light.yaml
@@ -136,7 +136,10 @@ packages:
   # # Debug/local development fallback:    
   # pcm5122_dac: !include packages/dac-pcm5122.yaml
   # amp_unmute: !include packages/amp-unmute.yaml
-  # snapclient: !include packages/snapclient.yaml
+  snapclient: !include packages/snapclient-new.yaml
+  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  dac_enable: !include packages/snapclient-addon-dac-enable.yaml
+  amp_enable: !include packages/snapclient-addon-amp-enable.yaml
   # # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml
 
   # light: !include packages/light.yaml

--- a/firmware/esphome/8-amped-esp32-plus/amped-esp32-s3-plus-idf-snapclient.yaml
+++ b/firmware/esphome/8-amped-esp32-plus/amped-esp32-s3-plus-idf-snapclient.yaml
@@ -137,7 +137,7 @@ packages:
   # pcm5122_dac: !include packages/dac-pcm5122.yaml
   # amp_unmute: !include packages/amp-unmute.yaml
   snapclient: !include packages/snapclient-new.yaml
-  extenal_dac: !include packages/snapclient-addon-external-dac.yaml
+  external_dac_addon: !include packages/snapclient-addon-external-dac.yaml
   dac_enable: !include packages/snapclient-addon-dac-enable.yaml
   amp_enable: !include packages/snapclient-addon-amp-enable.yaml
   # # snapclient_with_dsp: !include packages/snapclient-with-dsp.yaml

--- a/firmware/esphome/packages/dac-tas58xx-biamp.yaml
+++ b/firmware/esphome/packages/dac-tas58xx-biamp.yaml
@@ -23,7 +23,9 @@ substitutions:
   tas58xx_analog_gain: 0db     # Startup Gain or Output voltage swing
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
-  tas58xx_refresh_eq: AUTO
+  tas58xx_refresh_eq: AUTO     # AUTO applicable when audio playback triggered at boot, MANUAL requires to trigger EQ refresh with automation
+  tas58xx_dac_restore_mode: ALWAYS_ON  
+
 external_components:
   - source: github://mrtoy-me/esphome-tas58xx@main
     components: [tas58xx]
@@ -55,7 +57,7 @@ switch:
     enable_dac:
       name: Enable DAC
       id: enable_dac
-      restore_mode: ALWAYS_ON 
+      restore_mode: ${tas58xx_dac_restore_mode} 
 
 
 select:
@@ -64,6 +66,7 @@ select:
       name: _Mixer Mode
     eq_mode:
       name: EQ Mode
+      id: tas58xx_eq_mode_select
       
 number:
   - platform: tas58xx

--- a/firmware/esphome/packages/dac-tas58xx-biamp.yaml
+++ b/firmware/esphome/packages/dac-tas58xx-biamp.yaml
@@ -13,6 +13,7 @@
 #   - tas58xx_analog_gain: 0db (default)
 #   - tas58xx_volume_max:  0dB (default)
 #   - tas58xx_volume_min:  -60dB (default)
+#   - tas58xx_refresh_eq:  AUTO (default)
 # ============================================================
 
 substitutions:
@@ -22,6 +23,7 @@ substitutions:
   tas58xx_analog_gain: 0db     # Startup Gain or Output voltage swing
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
+  tas58xx_refresh_eq: AUTO
 external_components:
   - source: github://mrtoy-me/esphome-tas58xx@main
     components: [tas58xx]
@@ -45,6 +47,7 @@ audio_dac:
     analog_gain: ${tas58xx_analog_gain} # Startup Gain or Output voltage swing - pick based on the power supply voltage: https://github.com/sonocotta/esp32-tas5805m-dac?tab=readme-ov-file#digital-volume-and-analog-gain
     volume_max: ${tas58xx_volume_max}   # Max HA volume mapping to Digital Volume control, goes as high as +24dB, but not recommend going much above 0 dB, risking to cause clipping on high volume
     volume_min: ${tas58xx_volume_min}   # Min HA volume mapping to Digital Volume control, goes as low as -103dB, but prefer to set higher to have a reasonable volume range
+    refresh_eq: ${tas58xx_refresh_eq}
     update_interval: 5s                 # How often fault registers are read and cleared
 
 switch:

--- a/firmware/esphome/packages/dac-tas58xx-biamp.yaml
+++ b/firmware/esphome/packages/dac-tas58xx-biamp.yaml
@@ -24,10 +24,11 @@ substitutions:
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
   tas58xx_refresh_eq: AUTO     # AUTO applicable when audio playback triggered at boot, MANUAL requires to trigger EQ refresh with automation
+  tas58xx_branch: main         # Branch of the esphome-tas58xx component to use, default to 'main' for stable code
   tas58xx_dac_restore_mode: ALWAYS_ON  
 
 external_components:
-  - source: github://mrtoy-me/esphome-tas58xx@main
+  - source: github://mrtoy-me/esphome-tas58xx@${tas58xx_branch}
     components: [tas58xx]
     refresh: 48h
 

--- a/firmware/esphome/packages/dac-tas58xx-presets.yaml
+++ b/firmware/esphome/packages/dac-tas58xx-presets.yaml
@@ -13,6 +13,7 @@
 #   - tas58xx_analog_gain: 0db (default)
 #   - tas58xx_volume_max:  0dB (default)
 #   - tas58xx_volume_min:  -60dB (default)
+#   - tas58xx_refresh_eq:  AUTO (default)
 # ============================================================
 
 substitutions:
@@ -22,6 +23,7 @@ substitutions:
   tas58xx_analog_gain: 0db     # Startup Gain or Output voltage swing
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
+  tas58xx_refresh_eq: AUTO
 external_components:
   - source: github://mrtoy-me/esphome-tas58xx@main
     components: [tas58xx]
@@ -45,6 +47,7 @@ audio_dac:
     analog_gain: ${tas58xx_analog_gain} # Startup Gain or Output voltage swing - pick based on the power supply voltage: https://github.com/sonocotta/esp32-tas5805m-dac?tab=readme-ov-file#digital-volume-and-analog-gain
     volume_max: ${tas58xx_volume_max}   # Max HA volume mapping to Digital Volume control, goes as high as +24dB, but not recommend going much above 0 dB, risking to cause clipping on high volume
     volume_min: ${tas58xx_volume_min}   # Min HA volume mapping to Digital Volume control, goes as low as -103dB, but prefer to set higher to have a reasonable volume range
+    refresh_eq: ${tas58xx_refresh_eq}
     update_interval: 5s                 # How often fault registers are read and cleared
 
 switch:

--- a/firmware/esphome/packages/dac-tas58xx-presets.yaml
+++ b/firmware/esphome/packages/dac-tas58xx-presets.yaml
@@ -23,7 +23,9 @@ substitutions:
   tas58xx_analog_gain: 0db     # Startup Gain or Output voltage swing
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
-  tas58xx_refresh_eq: AUTO
+  tas58xx_refresh_eq: AUTO     # AUTO applicable when audio playback triggered at boot, MANUAL requires to trigger EQ refresh with automation
+  tas58xx_dac_restore_mode: ALWAYS_ON  
+
 external_components:
   - source: github://mrtoy-me/esphome-tas58xx@main
     components: [tas58xx]
@@ -55,7 +57,7 @@ switch:
     enable_dac:
       name: Enable DAC
       id: enable_dac
-      restore_mode: ALWAYS_ON 
+      restore_mode: ${tas58xx_dac_restore_mode}
 
 select:
   - platform: tas58xx
@@ -64,6 +66,7 @@ select:
     # eq_mode required if Number left_eq_gains/Right_eq_gains or eq_preset_left_channel/eq_preset_right_channel are configured
     eq_mode:
       name: EQ Mode
+      id: tas58xx_eq_mode_select
     # new eq presets - both must be defined and cannot be used with left_eq_gains and right_eq_gains
     eq_preset_left_channel:
       name: EQ Preset Cutoff Left Channel

--- a/firmware/esphome/packages/dac-tas58xx-presets.yaml
+++ b/firmware/esphome/packages/dac-tas58xx-presets.yaml
@@ -24,10 +24,11 @@ substitutions:
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
   tas58xx_refresh_eq: AUTO     # AUTO applicable when audio playback triggered at boot, MANUAL requires to trigger EQ refresh with automation
+  tas58xx_branch: main         # Branch of the esphome-tas58xx component to use, default to 'main' for stable code
   tas58xx_dac_restore_mode: ALWAYS_ON  
 
 external_components:
-  - source: github://mrtoy-me/esphome-tas58xx@main
+  - source: github://mrtoy-me/esphome-tas58xx@${tas58xx_branch}
     components: [tas58xx]
     refresh: 48h
 

--- a/firmware/esphome/packages/dac-tas58xx.yaml
+++ b/firmware/esphome/packages/dac-tas58xx.yaml
@@ -13,6 +13,7 @@
 #   - tas58xx_analog_gain: 0db (default)
 #   - tas58xx_volume_max:  0dB (default)
 #   - tas58xx_volume_min:  -60dB (default)
+#   - tas58xx_refresh_eq:  AUTO (default)
 # ============================================================
 
 substitutions:
@@ -22,6 +23,7 @@ substitutions:
   tas58xx_analog_gain: 0db     # Startup Gain or Output voltage swing
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
+  tas58xx_refresh_eq: AUTO
 external_components:
   - source: github://mrtoy-me/esphome-tas58xx@main
     components: [tas58xx]
@@ -45,6 +47,7 @@ audio_dac:
     analog_gain: ${tas58xx_analog_gain} # Startup Gain or Output voltage swing - pick based on the power supply voltage: https://github.com/sonocotta/esp32-tas5805m-dac?tab=readme-ov-file#digital-volume-and-analog-gain
     volume_max: ${tas58xx_volume_max}   # Max HA volume mapping to Digital Volume control, goes as high as +24dB, but not recommend going much above 0 dB, risking to cause clipping on high volume
     volume_min: ${tas58xx_volume_min}   # Min HA volume mapping to Digital Volume control, goes as low as -103dB, but prefer to set higher to have a reasonable volume range
+    refresh_eq: ${tas58xx_refresh_eq}
     update_interval: 5s                 # How often fault registers are read and cleared
 
 switch:

--- a/firmware/esphome/packages/dac-tas58xx.yaml
+++ b/firmware/esphome/packages/dac-tas58xx.yaml
@@ -63,7 +63,7 @@ select:
       name: _Mixer Mode
     eq_mode:
       name: EQ Mode
-      id: tas58xx_eq_mode
+      id: tas58xx_eq_mode_select
 
 number:
   - platform: tas58xx

--- a/firmware/esphome/packages/dac-tas58xx.yaml
+++ b/firmware/esphome/packages/dac-tas58xx.yaml
@@ -63,6 +63,7 @@ select:
       name: _Mixer Mode
     eq_mode:
       name: EQ Mode
+      id: tas58xx_eq_mode
 
 number:
   - platform: tas58xx

--- a/firmware/esphome/packages/dac-tas58xx.yaml
+++ b/firmware/esphome/packages/dac-tas58xx.yaml
@@ -24,10 +24,11 @@ substitutions:
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
   tas58xx_refresh_eq: AUTO     # AUTO applicable when audio playback triggered at boot, MANUAL requires to trigger EQ refresh with automation
+  tas58xx_branch: main         # Branch of the esphome-tas58xx component to use, default to 'main' for stable code
   tas58xx_dac_restore_mode: ALWAYS_ON  
 
 external_components:
-  - source: github://mrtoy-me/esphome-tas58xx@main
+  - source: github://mrtoy-me/esphome-tas58xx@${tas58xx_branch}
     components: [tas58xx]
     refresh: 48h
 

--- a/firmware/esphome/packages/dac-tas58xx.yaml
+++ b/firmware/esphome/packages/dac-tas58xx.yaml
@@ -23,7 +23,9 @@ substitutions:
   tas58xx_analog_gain: 0db     # Startup Gain or Output voltage swing
   tas58xx_volume_max: 0dB      # Max HA volume mapping to Digital Volume control
   tas58xx_volume_min: -60dB    # Min HA volume mapping to Digital Volume control
-  tas58xx_refresh_eq: AUTO
+  tas58xx_refresh_eq: AUTO     # AUTO applicable when audio playback triggered at boot, MANUAL requires to trigger EQ refresh with automation
+  tas58xx_dac_restore_mode: ALWAYS_ON  
+
 external_components:
   - source: github://mrtoy-me/esphome-tas58xx@main
     components: [tas58xx]
@@ -55,7 +57,7 @@ switch:
     enable_dac:
       name: Enable DAC
       id: enable_dac
-      restore_mode: ALWAYS_ON 
+      restore_mode: ${tas58xx_dac_restore_mode}
 
 select:
   - platform: tas58xx

--- a/firmware/esphome/packages/snapclient-addon-amp-enable.yaml
+++ b/firmware/esphome/packages/snapclient-addon-amp-enable.yaml
@@ -1,0 +1,24 @@
+# ============================================================
+# Media Player - Amp enable addon
+# ============================================================
+# Extends snapclient media player with Amp enable control
+# Dependencies: snapclient-new.yaml (speaker stack)
+# amp-unmute.yaml (Amp enable switch)
+# ============================================================
+
+media_player:
+  - id: !extend snapclient_media_player
+
+    on_play:
+      - if:
+          condition:
+            switch.is_off: enable_amp
+          then:
+            switch.turn_on: enable_amp
+
+    on_idle:
+      - if:
+          condition:
+            switch.is_on: enable_amp
+          then:
+            switch.turn_off: enable_amp

--- a/firmware/esphome/packages/snapclient-addon-dac-enable.yaml
+++ b/firmware/esphome/packages/snapclient-addon-dac-enable.yaml
@@ -1,12 +1,10 @@
 # ============================================================
-# Media Player - AC enable addon
+# Media Player - DAC enable addon
 # ============================================================
-# Configures media player with DAC enable control
-# Requires substitutions:
-#   - friendly_name
-#   - dac_enable_pin
-# Dependencies: media-player.yaml (speaker stack)
+# Extends snapclient media player with DAC enable control
+# Dependencies: snapclient-new.yaml (speaker stack)
 # dac-switch.yaml (DAC enable switch)
+# or tas58xx-dac.yaml (DAC enable switch included in DAC component)
 # ============================================================
 
 media_player:

--- a/firmware/esphome/packages/snapclient-addon-dac-enable.yaml
+++ b/firmware/esphome/packages/snapclient-addon-dac-enable.yaml
@@ -1,0 +1,27 @@
+# ============================================================
+# Media Player - AC enable addon
+# ============================================================
+# Configures media player with DAC enable control
+# Requires substitutions:
+#   - friendly_name
+#   - dac_enable_pin
+# Dependencies: media-player.yaml (speaker stack)
+# dac-switch.yaml (DAC enable switch)
+# ============================================================
+
+media_player:
+  - id: !extend snapclient_media_player
+
+    on_play:
+      - if:
+          condition:
+            switch.is_off: enable_dac
+          then:
+            switch.turn_on: enable_dac
+
+    on_idle:
+      - if:
+          condition:
+            switch.is_on: enable_dac
+          then:
+            switch.turn_off: enable_dac

--- a/firmware/esphome/packages/snapclient-addon-external-dac.yaml
+++ b/firmware/esphome/packages/snapclient-addon-external-dac.yaml
@@ -5,6 +5,6 @@
 # by attaching a configured external DAC component.
 # ============================================================
 
-speaker:
+media_player:
   - id: !extend snapclient_media_player
     audio_dac: external_dac

--- a/firmware/esphome/packages/snapclient-addon-external-dac.yaml
+++ b/firmware/esphome/packages/snapclient-addon-external-dac.yaml
@@ -1,0 +1,10 @@
+# ============================================================
+# Snapclient media player - External DAC addon
+# ============================================================
+# Extends Snapclient media player configuration from snapclient-new.yaml
+# by attaching a configured external DAC component.
+# ============================================================
+
+speaker:
+  - id: !extend snapclient_media_player
+    audio_dac: external_dac

--- a/firmware/esphome/packages/snapclient-addon-tas58xx.yaml
+++ b/firmware/esphome/packages/snapclient-addon-tas58xx.yaml
@@ -1,0 +1,29 @@
+# ============================================================
+# Media Player - TAS58XX EQ enable addon
+# ============================================================
+# Extends snapclient media player with TAS58XX EQ enable control
+# Dependencies: snapclient-new.yaml (speaker stack)
+# tas58xx-dac.yaml (EQ enable switch included in DAC component)
+# ============================================================
+
+globals:
+  - id: eq_applied
+    type: bool
+    initial_value: 'false'
+
+media_player:
+  - id: !extend snapclient_media_player
+
+    on_play:
+      - if:
+          condition:
+            - lambda: return (!id(eq_applied));
+          then:
+            - logger.log: "Playback started!"
+            #- delay: 1000ms
+            - select.set_index:
+                id: tas58xx_eq_mode_select
+                index: 1 # Enabled
+            - globals.set:
+                id: eq_applied
+                value: 'true' 

--- a/firmware/esphome/packages/snapclient-addon-tas58xx.yaml
+++ b/firmware/esphome/packages/snapclient-addon-tas58xx.yaml
@@ -13,17 +13,16 @@ globals:
 
 media_player:
   - id: !extend snapclient_media_player
-
     on_play:
-      - wait_until:
-          condition:
-            switch.is_on: enable_dac
-      - delay: 1000ms
       - if:
           condition:
             - lambda: return (!id(eq_applied));
           then:
             - logger.log: "Playback started!"
+            - wait_until:
+                condition:
+                  switch.is_on: enable_dac
+            - delay: 1000ms
             - select.set_index:
                 id: tas58xx_eq_mode_select
                 index: 1 # Enabled

--- a/firmware/esphome/packages/snapclient-addon-tas58xx.yaml
+++ b/firmware/esphome/packages/snapclient-addon-tas58xx.yaml
@@ -15,12 +15,15 @@ media_player:
   - id: !extend snapclient_media_player
 
     on_play:
+      - wait_until:
+          condition:
+            switch.is_on: enable_dac
+      - delay: 1000ms
       - if:
           condition:
             - lambda: return (!id(eq_applied));
           then:
             - logger.log: "Playback started!"
-            #- delay: 1000ms
             - select.set_index:
                 id: tas58xx_eq_mode_select
                 index: 1 # Enabled

--- a/firmware/esphome/packages/snapclient-new.yaml
+++ b/firmware/esphome/packages/snapclient-new.yaml
@@ -7,20 +7,36 @@ i2s_audio:
   i2s_lrclk_pin: ${i2s_lrclk_pin}
   i2s_bclk_pin: ${i2s_bclk_pin}
 
+globals:
+  - id: eq_applied
+    type: bool
+    initial_value: 'false'
+
 media_player:
   - platform: snapclient
     hostname: ${snapcast_server_ip}
     port: ${snapcast_server_port}
     name: ${friendly_name}
+    id: snapclient_media_player
     audio_dac: external_dac
     i2s_dout_pin: ${i2s_dout_pin}
+
     on_play:
-      - logger.log: "Playback started!"
-      #- delay: 1000ms
-      - select.set:
-          id: tas58xx_eq_mode_select
-          option: "EQ 15 Band"
+    - if:
+          condition:
+            - lambda: return (!id(eq_applied));
+          then:
+            - logger.log: "Playback started!"
+            #- delay: 1000ms
+            - select.set_index:
+                id: tas58xx_eq_mode_select
+                index: 1 # Enabled
+            - globals.set:
+                id: eq_applied
+                value: 'true' 
+    
     on_pause:
       - logger.log: "Playback paused!"
+    
     on_idle:
       - logger.log: "Playback finished!"

--- a/firmware/esphome/packages/snapclient-new.yaml
+++ b/firmware/esphome/packages/snapclient-new.yaml
@@ -7,11 +7,6 @@ i2s_audio:
   i2s_lrclk_pin: ${i2s_lrclk_pin}
   i2s_bclk_pin: ${i2s_bclk_pin}
 
-globals:
-  - id: eq_applied
-    type: bool
-    initial_value: 'false'
-
 media_player:
   - platform: snapclient
     hostname: ${snapcast_server_ip}
@@ -22,18 +17,7 @@ media_player:
     i2s_dout_pin: ${i2s_dout_pin}
 
     on_play:
-    - if:
-          condition:
-            - lambda: return (!id(eq_applied));
-          then:
-            - logger.log: "Playback started!"
-            #- delay: 1000ms
-            - select.set_index:
-                id: tas58xx_eq_mode_select
-                index: 1 # Enabled
-            - globals.set:
-                id: eq_applied
-                value: 'true' 
+      - logger.log: "Playback started!"
     
     on_pause:
       - logger.log: "Playback paused!"

--- a/firmware/esphome/packages/snapclient-new.yaml
+++ b/firmware/esphome/packages/snapclient-new.yaml
@@ -1,0 +1,22 @@
+external_components:
+  - source: github://pr#14389
+    components: [ snapclient ]
+    refresh: 24h
+
+i2s_audio:
+  i2s_lrclk_pin: ${i2s_lrclk_pin}
+  i2s_bclk_pin: ${i2s_bclk_pin}
+
+media_player:
+  - platform: snapclient
+    hostname: ${snapcast_server_ip}
+    port: ${snapcast_server_port}
+    name: ${friendly_name}
+    audio_dac: external_dac
+    i2s_dout_pin: ${i2s_dout_pin}
+    on_play:
+      - logger.log: "Playback started!"
+    on_pause:
+      - logger.log: "Playback paused!"
+    on_idle:
+      - logger.log: "Playback finished!"

--- a/firmware/esphome/packages/snapclient-new.yaml
+++ b/firmware/esphome/packages/snapclient-new.yaml
@@ -13,7 +13,6 @@ media_player:
     port: ${snapcast_server_port}
     name: ${friendly_name}
     id: snapclient_media_player
-    audio_dac: external_dac
     i2s_dout_pin: ${i2s_dout_pin}
 
     on_play:

--- a/firmware/esphome/packages/snapclient-new.yaml
+++ b/firmware/esphome/packages/snapclient-new.yaml
@@ -16,6 +16,10 @@ media_player:
     i2s_dout_pin: ${i2s_dout_pin}
     on_play:
       - logger.log: "Playback started!"
+      - delay: 1000ms
+      - select.set:
+          id: tas58xx_eq_mode_select
+          option: "EQ 15 Band"
     on_pause:
       - logger.log: "Playback paused!"
     on_idle:

--- a/firmware/esphome/packages/snapclient-new.yaml
+++ b/firmware/esphome/packages/snapclient-new.yaml
@@ -16,7 +16,7 @@ media_player:
     i2s_dout_pin: ${i2s_dout_pin}
     on_play:
       - logger.log: "Playback started!"
-      - delay: 1000ms
+      #- delay: 1000ms
       - select.set:
           id: tas58xx_eq_mode_select
           option: "EQ 15 Band"


### PR DESCRIPTION
When using the tas58xx dac module with snapclient the refresh_eq needs to be MANUAL instead of AUTO, see https://github.com/mrtoy-me/esphome-tas58xx#use-case-where-speaker-mediaplayer-is-not-used-eg-using-a-snapcast-client-component.

This PR adds the refresh_eq override for the snapclient examples.