### PR TITLE
Migrating TFT display to `mipi_spi`

### DIFF
--- a/firmware/esphome/packages/sendspin-addon-tft.yaml
+++ b/firmware/esphome/packages/sendspin-addon-tft.yaml
@@ -315,13 +315,8 @@ generic_image:
       - logger.log: "Failed to decode artist picture"
 
 display:
-  - platform: ili9xxx
+  - platform: mipi_spi
     model: ${display_model}
-    dimensions:
-      width: 320
-      height: 240
-      offset_height: 0
-      offset_width: 0
     color_order: RGB
     invert_colors: true
     # rotation: 90

--- a/firmware/esphome/packages/tft-spi.yaml
+++ b/firmware/esphome/packages/tft-spi.yaml
@@ -42,14 +42,9 @@ switch:
 
 ### Example display configuration, showing the current playback state
 display:
-  - platform: ili9xxx
+  - platform: mipi_spi
     id: tft_display
     model: ${display_model}
-    dimensions:
-      width: 320
-      height: 240
-      offset_height: 0
-      offset_width: 0
     invert_colors: true
     dc_pin: ${display_dc_pin}
     reset_pin: ${display_reset_pin}

--- a/firmware/esphome/packages/tft-spi.yaml
+++ b/firmware/esphome/packages/tft-spi.yaml
@@ -10,6 +10,9 @@
 #   - display_reset_pin
 # ============================================================
 
+defaults:
+  display_model: ILI9341
+
 # prerequisites:
 font:
   - file:
@@ -41,7 +44,7 @@ switch:
 display:
   - platform: ili9xxx
     id: tft_display
-    model: ILI9341
+    model: ${display_model}
     dimensions:
       width: 320
       height: 240


### PR DESCRIPTION
Hi,

Thanks for the great project!
This PR migrates TFT display to `mipi_spi`component (instead of `ili9xxx`, which will be removed in the future).
I also removed `dimensions`, as those are automatically set (unless the display model is `CUSTOM`).